### PR TITLE
Support event creation notifications

### DIFF
--- a/lib/Net/Google/CalendarV3.pm
+++ b/lib/Net/Google/CalendarV3.pm
@@ -68,7 +68,8 @@ method get_entry ($entry_id) {
 
 method add_entry ($entry) {
     $entry->{-calendarId} = $self->_current_calendar;
-    my $res = $self->_service->post('/calendars/[% calendarId %]/events', $entry);
+    $entry->{-sendNotifications} //= 'False';
+    my $res = $self->_service->post('/calendars/[% calendarId %]/events?sendNotifications=[% sendNotifications %]', $entry);
     die $res->error unless $res->success;
     $entry = to_Event($res->res);
 }


### PR DESCRIPTION
This PR adds support for sending notifications upon event creation via the
`sendNotifications` parameter as described in the [Google Calendar API
reference](https://developers.google.com/google-apps/calendar/v3/reference/events/insert).

Please review and merge, or let me know if you'd like me to tweak it more first :)