### PR TITLE
Add missing dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,6 +11,7 @@ copyright_holder = Rhesa Rozendaal
 DateTime::Format::ISO8601 = 0
 JSON::XS    = 0
 Kavorka     = 0
+LWP::Protocol::https = 0
 Moose       = 0
 Try::Tiny   = 0
 Types::Standard = 0


### PR DESCRIPTION
This PR adds `LWP::Protocol::https` as dependency.

It looks like `Net::Google::CalendarV3` would contact Google's endpoints via
HTTPS, but when trying to install it on top of a vanilla Perl environment,
`LWP::Protocol::https` is not being pulled in as a dependency for some reason.

Please review and merge, or let me know if you'd like me to tweak it more
first :)