### PR TITLE
Provide the default value for event attendees

### DIFF
--- a/lib/Net/Google/CalendarV3/Event.pm
+++ b/lib/Net/Google/CalendarV3/Event.pm
@@ -25,7 +25,7 @@ has [ qw( anyoneCanAddSelf attendeesOmitted colorId description
 has '+kind' => default => 'calendar#event';
 
 has [ qw( +creator +organizer ) ], isa => Person, coerce => 1;
-has '+attendees', isa => ArrayRef[Attendee], coerce => 1;
+has '+attendees', isa => ArrayRef[Attendee], default => sub { return []; }, coerce => 1;
 has [ qw( +anyoneCanAddSelf +attendeesOmitted
         +guestsCanInviteOthers +guestsCanSeeOtherGuests
         +locked +privateCopy


### PR DESCRIPTION
When reading an event without attendees, the `attendees` has the
value of `undef`. Since this accessor is read-only, there is no
way then to populate the attendees and update the event.

This makes sure that the default value for attendees is always
an arrayref. This way, constructs like

```
@{ $entry->attendees } = @attendees;
```

are going to always work, whether we create new events or read existing events.